### PR TITLE
Add drag start and end events

### DIFF
--- a/js/simple-slider.js
+++ b/js/simple-slider.js
@@ -371,7 +371,7 @@ var __slice = [].slice,
       if ($el.data("slider-theme")) {
         settings.theme = $el.data("slider-theme");
       }
-      if ($el.attr("data-slider-highlight")) {
+      if ($el.data("slider-highlight")) {
         settings.highlight = $el.data("slider-highlight");
       }
       if ($el.data("slider-animate") != null) {

--- a/js/simple-slider.js
+++ b/js/simple-slider.js
@@ -14,8 +14,7 @@ var __slice = [].slice,
   SimpleSlider = (function() {
 
     function SimpleSlider(input, options) {
-      var ratio,
-        _this = this;
+      var _this = this;
       this.input = input;
       this.defaultOptions = {
         animate: true,
@@ -78,15 +77,7 @@ var __slice = [].slice,
         }
         _this.dragging = true;
         _this.dragger.addClass("dragging");
-        ratio = _this.valueToRatio(this.value);
-        var eventData = {
-          value: _this.value,
-          ratio: ratio,
-          position: ratio * _this.slider.outerWidth(),
-          el: _this.slider
-        };
-
-        _this.input.trigger("slider:drag-started", eventData);
+        _this.input.trigger("slider:drag-started", _this._makeEventData());
         _this.domDrag(e.pageX, e.pageY);
         return false;
       });
@@ -101,15 +92,7 @@ var __slice = [].slice,
         if (_this.dragging) {
           _this.dragging = false;
           _this.dragger.removeClass("dragging");
-          ratio = _this.valueToRatio(this.value);
-          var eventData = {
-            value: _this.value,
-            ratio: ratio,
-            position: ratio * _this.slider.outerWidth(),
-            el: _this.slider
-          };
-
-          _this.input.trigger("slider:drag-ended", eventData);
+          _this.input.trigger("slider:drag-ended", _this._makeEventData());
           // Post final position here
           _this.domDrag(e.pageX, e.pageY, false);
           return $("body").css({
@@ -125,13 +108,7 @@ var __slice = [].slice,
         this.value = this.nearestValidValue(this.input.val());
       }
       this.setSliderPositionFromValue(this.value);
-      ratio = this.valueToRatio(this.value);
-      this.input.trigger("slider:ready", {
-        value: this.value,
-        ratio: ratio,
-        position: ratio * this.slider.outerWidth(),
-        el: this.slider
-      });
+      this.input.trigger("slider:ready", this._makeEventData());
     }
 
     SimpleSlider.prototype.createDivElement = function(classname) {
@@ -312,14 +289,20 @@ var __slice = [].slice,
         return;
       }
       this.value = value;
-      eventData = {
-        value: value,
-        ratio: ratio,
-        position: ratio * this.slider.outerWidth(),
+      eventData = this._makeEventData(value, ratio, trigger);
+      return this.input.val(value).trigger($.Event("change", eventData)).trigger("slider:changed", eventData);
+    };
+
+    SimpleSlider.prototype._makeEventData = function(value, ratio, trigger) {
+      var v = value || this.value,
+          r = ratio || this.valueToRatio(v);
+      return {
+        value: v,
+        ratio: r,
+        position: r * this.slider.outerWidth(),
         trigger: trigger,
         el: this.slider
       };
-      return this.input.val(value).trigger($.Event("change", eventData)).trigger("slider:changed", eventData);
     };
 
     return SimpleSlider;

--- a/js/simple-slider.js
+++ b/js/simple-slider.js
@@ -78,6 +78,15 @@ var __slice = [].slice,
         }
         _this.dragging = true;
         _this.dragger.addClass("dragging");
+        ratio = _this.valueToRatio(this.value);
+        var eventData = {
+          value: _this.value,
+          ratio: ratio,
+          position: ratio * _this.slider.outerWidth(),
+          el: _this.slider
+        };
+
+        _this.input.trigger("slider:drag-started", eventData);
         _this.domDrag(e.pageX, e.pageY);
         return false;
       });
@@ -92,6 +101,17 @@ var __slice = [].slice,
         if (_this.dragging) {
           _this.dragging = false;
           _this.dragger.removeClass("dragging");
+          ratio = _this.valueToRatio(this.value);
+          var eventData = {
+            value: _this.value,
+            ratio: ratio,
+            position: ratio * _this.slider.outerWidth(),
+            el: _this.slider
+          };
+
+          _this.input.trigger("slider:drag-ended", eventData);
+          // Post final position here
+          _this.domDrag(e.pageX, e.pageY, false);
           return $("body").css({
             cursor: "auto"
           });


### PR DESCRIPTION
- fires `slider:drag-started` on mousedown
- fires `slider:drag-ended` on mouseup
- factors event data construction out to helper method

Useful if client code wants to throttle rapid change events from dragging, etc. Addresses issue #9 .
